### PR TITLE
Fix NeoForge crash on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ repositories {
   maven {
     // Location of the maven that hosts Team Resourceful's jars.
     name = "Resourceful Bees Maven"
-    url = "https://nexus.resourcefulbees.com/repository/maven-public/"
+    url = "https://maven.teamresourceful.com/repository/maven-public/"
   }
 }
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ subprojects {
     }
 
     repositories {
-        maven { url "https://maven.resourcefulbees.com/repository/maven-public/"}
+        maven { url "https://maven.teamresourceful.com/repository/maven-public/"}
         maven { url "https://maven.neoforged.net/releases/" }
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/neoforge/src/main/java/com/teamresourceful/resourcefulconfig/common/utils/neoforge/ModUtilsImpl.java
+++ b/neoforge/src/main/java/com/teamresourceful/resourcefulconfig/common/utils/neoforge/ModUtilsImpl.java
@@ -1,4 +1,4 @@
-package com.teamresourceful.resourcefulconfig.common.utils.forge;
+package com.teamresourceful.resourcefulconfig.common.utils.neoforge;
 
 import net.neoforged.fml.loading.FMLPaths;
 

--- a/neoforge/src/main/java/com/teamresourceful/resourcefulconfig/neoforge/ResourcefulconfigNeoForge.java
+++ b/neoforge/src/main/java/com/teamresourceful/resourcefulconfig/neoforge/ResourcefulconfigNeoForge.java
@@ -1,12 +1,12 @@
-package com.teamresourceful.resourcefulconfig.forge;
+package com.teamresourceful.resourcefulconfig.neoforge;
 
 import com.teamresourceful.resourcefulconfig.web.server.WebServer;
 import net.neoforged.fml.common.Mod;
 
 @Mod("resourcefulconfig")
-public class ResourcefulconfigForge {
+public class ResourcefulconfigNeoForge {
 
-    public ResourcefulconfigForge() {
+    public ResourcefulconfigNeoForge() {
         WebServer.start();
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,7 +3,7 @@ pluginManagement {
         maven { url "https://maven.fabricmc.net/" }
         maven { url "https://maven.architectury.dev/" }
         maven { url "https://maven.minecraftforge.net/" }
-        maven { url "https://maven.resourcefulbees.com/repository/maven-public/"}
+        maven { url "https://maven.teamresourceful.com/repository/maven-public/"}
         gradlePluginPortal()
     }
 }


### PR DESCRIPTION
- Fixes neoforge crash on startup due to incorrect package names
- Also updates gradle to `8.5` and updates maven to `maven.teamresourceful.com`