### PR TITLE
[Fabric] Remove 'icon' field from fabric.mod.json

### DIFF
--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -13,7 +13,6 @@
         "homepage": "https://resourcefulbees.com"
     },
     "license": "MIT",
-    "icon": "icon.png",
     "environment": "*",
     "depends": {
         "fabricloader": ">=0.14.21",


### PR DESCRIPTION
Removes reference to a nonexistent icon to prevent console log spamming when inside the fabric mod menu.

Should fix #23.