### PR TITLE
Fixed the alpha setting for shown preset colors not applying correctly.

### DIFF
--- a/common/src/main/java/com/teamresourceful/resourcefulconfig/client/components/options/types/color/PresetsSelector.java
+++ b/common/src/main/java/com/teamresourceful/resourcefulconfig/client/components/options/types/color/PresetsSelector.java
@@ -43,8 +43,8 @@ public class PresetsSelector extends BaseWidget {
         this.presets = presets;
         this.type = type;
         this.state = state;
-        this.getColors();
         this.withAlpha = withAlpha;
+        this.getColors();
     }
 
     private Collection<HsbColor> getColors() {


### PR DESCRIPTION
The order of calling the `getColors()` method in the constructor is incorrect.
Since `getColors()` is called before the assignment of `withAlpha`, all usages of that field use the default value `withAlpha`, which means that it is currently impossible to provide color presets with an alpha value.